### PR TITLE
Prefer "object" over "dict" in API specs

### DIFF
--- a/src/tooltalk/apis/account.py
+++ b/src/tooltalk/apis/account.py
@@ -184,7 +184,7 @@ class QueryUser(AccountAPI):
         "users": {
             "type": "array",
             "item": {
-                "type": "dict",
+                "type": "object",
                 "description": "The account information of the user.",
                 "properties": {
                     'username': {'type': "string", 'description': 'The username of the user.'},
@@ -270,7 +270,7 @@ class RegisterUser(AccountAPI):
     }
     output = {
         "session_token": {'type': "string", 'description': 'The token of the user.'},
-        'user': {'type': 'dict', 'description': 'The account information of the user.'},
+        'user': {'type': 'object', 'description': 'The account information of the user.'},
     }
     database_name = ACCOUNT_DB_NAME
     is_action = True


### PR DESCRIPTION
A minor fix to consolidate all types in the API specs to [standard JSON-Schema types](https://json-schema.org/understanding-json-schema/reference/type).