### PR TITLE
Fix: prevent double-login, actually

### DIFF
--- a/src/tooltalk/evaluation/tool_executor.py
+++ b/src/tooltalk/evaluation/tool_executor.py
@@ -99,13 +99,14 @@ class ToolExecutor:
                     "exception": "User is not logged in"
                 }
                 return request, response
-            elif api_name in [UserLogin.__name__, RegisterUser.__name__]:
-                response = {
-                    "response": None,
-                    "exception": "Only one user can be logged in at a time"
-                }
-                return request, response
             parameters["session_token"] = self.session_token
+        if api_name in [UserLogin.__name__, RegisterUser.__name__] and self.session_token is not None:
+            username = tool.check_session_token(self.session_token)["username"]
+            response = {
+                "response": None,
+                "exception": f"Only one user can be logged in at a time. Current user is {username}.",
+            }
+            return request, response
 
         # execute tool
         response = tool(**parameters)


### PR DESCRIPTION
As neither `UserLogin` nor `RegisterUser` has their `requires_auth` attribute set to `True`, the current code path for the "double-login" check will actually never be reached and activated (due to the following precondition https://github.com/microsoft/ToolTalk/blob/a8d8befb1ea098cd9fc363a7515028b0b2aeb903/src/tooltalk/evaluation/tool_executor.py#L95).

This change will fix it and also make the error message a little bit clearer.