### PR TITLE
Fix: apis_used & suites_used in ground-truth

### DIFF
--- a/data/tooltalk/AccountTools-Alarm-Calendar-AddAlarm-0.json
+++ b/data/tooltalk/AccountTools-Alarm-Calendar-AddAlarm-0.json
@@ -117,17 +117,5 @@
             "role": "user",
             "text": "Thanks, that's all for now."
         }
-    ],
-    "intended_apis_used": [
-        "LogoutUser",
-        "RegisterUser",
-        "AddAlarm",
-        "CreateEvent",
-        "QueryCalendar"
-    ],
-    "intended_suites_used": [
-        "AccountTools",
-        "Alarm",
-        "Calendar"
     ]
 }

--- a/data/tooltalk/AccountTools-Alarm-Calendar-AddAlarm-0.json
+++ b/data/tooltalk/AccountTools-Alarm-Calendar-AddAlarm-0.json
@@ -2,16 +2,14 @@
     "name": "AccountTools-Alarm-Calendar-AddAlarm-0",
     "conversation_id": "de6eb33d-0ea2-468e-bd84-ebf4ea3827c8",
     "suites_used": [
-        "AccountTools",
         "Alarm",
-        "Calendar"
+        "Calendar",
+        "AccountTools"
     ],
     "apis_used": [
-        "LogoutUser",
-        "RegisterUser",
-        "AddAlarm",
         "CreateEvent",
-        "QueryCalendar"
+        "AddAlarm",
+        "RegisterUser"
     ],
     "scenario": "The user wants to create a new account and set an alarm for an important meeting the next day. They use RegisterUser to sign up with their username, password, email, name, and phone. They receive a session_token and their account information. They use CreateEvent to add the meeting to their calendar, providing the name, event_type, description, start_time, end_time, location, and attendees. They receive an event_id on success. They use AddAlarm to set an alarm for 30 minutes before the meeting, providing their session_token and the time. They receive an alarm_id on success. They use QueryCalendar to check their schedule for the next day, providing their session_token, start_time, and end_time. They receive a list of events in the time range. They use LogoutUser to log out of their account, providing their session_token. They receive a status of success or failed.",
     "user": {
@@ -119,5 +117,17 @@
             "role": "user",
             "text": "Thanks, that's all for now."
         }
+    ],
+    "intended_apis_used": [
+        "LogoutUser",
+        "RegisterUser",
+        "AddAlarm",
+        "CreateEvent",
+        "QueryCalendar"
+    ],
+    "intended_suites_used": [
+        "AccountTools",
+        "Alarm",
+        "Calendar"
     ]
 }

--- a/data/tooltalk/AccountTools-Alarm-Email-GetAccountInformati-0.json
+++ b/data/tooltalk/AccountTools-Alarm-Email-GetAccountInformati-0.json
@@ -165,18 +165,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "ChangePassword",
-        "GetAccountInformation",
-        "LogoutUser",
-        "UpdateAccountInformation",
-        "UserLogin",
-        "SendEmail"
-    ],
-    "intended_suites_used": [
-        "AccountTools",
-        "Alarm",
-        "Email"
     ]
 }

--- a/data/tooltalk/AccountTools-Alarm-Email-GetAccountInformati-0.json
+++ b/data/tooltalk/AccountTools-Alarm-Email-GetAccountInformati-0.json
@@ -3,16 +3,14 @@
     "conversation_id": "c9c87c8a-4d76-4df2-ae6b-c9c336e72ec2",
     "suites_used": [
         "AccountTools",
-        "Alarm",
         "Email"
     ],
     "apis_used": [
-        "ChangePassword",
-        "GetAccountInformation",
-        "LogoutUser",
+        "SendEmail",
         "UpdateAccountInformation",
-        "UserLogin",
-        "SendEmail"
+        "LogoutUser",
+        "GetAccountInformation",
+        "UserLogin"
     ],
     "scenario": "The user wants to log in to their account and check their account information (UserLogin + GetAccountInformation). They notice that their email and phone number are outdated, so they decide to update them (UpdateAccountInformation). They also want to change their password to a more secure one (ChangePassword). They then want to send an email to their friend to let them know about their new contact details (SendEmail). They log out of their account after finishing their tasks (LogoutUser).",
     "user": {
@@ -167,5 +165,18 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "ChangePassword",
+        "GetAccountInformation",
+        "LogoutUser",
+        "UpdateAccountInformation",
+        "UserLogin",
+        "SendEmail"
+    ],
+    "intended_suites_used": [
+        "AccountTools",
+        "Alarm",
+        "Email"
     ]
 }

--- a/data/tooltalk/AccountTools-Alarm-Messages-FindAlarm-0.json
+++ b/data/tooltalk/AccountTools-Alarm-Messages-FindAlarm-0.json
@@ -2,17 +2,14 @@
     "name": "AccountTools-Alarm-Messages-FindAlarm-0",
     "conversation_id": "2527d668-fc2f-461d-8bb9-53ec3274c8ba",
     "suites_used": [
-        "AccountTools",
         "Alarm",
-        "Messages"
+        "AccountTools"
     ],
     "apis_used": [
-        "GetAccountInformation",
         "UserLogin",
         "AddAlarm",
         "DeleteAlarm",
-        "FindAlarms",
-        "SendMessage"
+        "FindAlarms"
     ],
     "scenario": "The user wants to set an alarm for 8:00 am to catch a flight. They use UserLogin to log in to the app. They use FindAlarms to check if they already have an alarm set for that time. They see that they have an alarm set for 7:30 am, but they want to change it. They use DeleteAlarm to remove the old alarm. They use AddAlarm to set a new alarm for 8:00 am..",
     "user": {
@@ -189,5 +186,18 @@
             "role": "user",
             "text": "No, that's all. Thanks!"
         }
+    ],
+    "intended_apis_used": [
+        "GetAccountInformation",
+        "UserLogin",
+        "AddAlarm",
+        "DeleteAlarm",
+        "FindAlarms",
+        "SendMessage"
+    ],
+    "intended_suites_used": [
+        "AccountTools",
+        "Alarm",
+        "Messages"
     ]
 }

--- a/data/tooltalk/AccountTools-Alarm-Messages-FindAlarm-0.json
+++ b/data/tooltalk/AccountTools-Alarm-Messages-FindAlarm-0.json
@@ -186,18 +186,5 @@
             "role": "user",
             "text": "No, that's all. Thanks!"
         }
-    ],
-    "intended_apis_used": [
-        "GetAccountInformation",
-        "UserLogin",
-        "AddAlarm",
-        "DeleteAlarm",
-        "FindAlarms",
-        "SendMessage"
-    ],
-    "intended_suites_used": [
-        "AccountTools",
-        "Alarm",
-        "Messages"
     ]
 }

--- a/data/tooltalk/AccountTools-Alarm-Weather-DeleteAccount-2.json
+++ b/data/tooltalk/AccountTools-Alarm-Weather-DeleteAccount-2.json
@@ -147,17 +147,5 @@
             "role": "user",
             "text": "No, that's all. Thanks for your help."
         }
-    ],
-    "intended_apis_used": [
-        "DeleteAccount",
-        "QueryUser",
-        "SendVerificationCode",
-        "UpdateAccountInformation",
-        "UserLogin"
-    ],
-    "intended_suites_used": [
-        "AccountTools",
-        "Alarm",
-        "Weather"
     ]
 }

--- a/data/tooltalk/AccountTools-Alarm-Weather-DeleteAccount-2.json
+++ b/data/tooltalk/AccountTools-Alarm-Weather-DeleteAccount-2.json
@@ -2,16 +2,13 @@
     "name": "AccountTools-Alarm-Weather-DeleteAccount-2",
     "conversation_id": "01874a95-d7de-48bc-b7a9-ffb1e26aa130",
     "suites_used": [
-        "AccountTools",
-        "Alarm",
-        "Weather"
+        "AccountTools"
     ],
     "apis_used": [
+        "UserLogin",
         "DeleteAccount",
-        "QueryUser",
-        "SendVerificationCode",
-        "UpdateAccountInformation",
-        "UserLogin"
+        "ResetPassword",
+        "SendVerificationCode"
     ],
     "scenario": "The user wants to delete their account because they forgot their password and cannot access it. They first try to reset their password by providing their username and email to the SendVerificationCode API. They receive a verification code in their email, but they realize that they also forgot their email password. They give up on resetting their password and decide to delete their account instead. They use the QueryUser API to find their account information using their username. They see that they have an alternative phone number registered with their account. They call the phone number and ask the person who answers to help them delete their account. The person agrees and logs in with their own username and password (UserLogin). They then use the UpdateAccountInformation API to change the email and phone number of the user's account to their own. They then use the DeleteAccount API to delete the user's account by providing the session token and password. They receive a confirmation message that the account has been deleted successfully.",
     "user": {
@@ -150,5 +147,17 @@
             "role": "user",
             "text": "No, that's all. Thanks for your help."
         }
+    ],
+    "intended_apis_used": [
+        "DeleteAccount",
+        "QueryUser",
+        "SendVerificationCode",
+        "UpdateAccountInformation",
+        "UserLogin"
+    ],
+    "intended_suites_used": [
+        "AccountTools",
+        "Alarm",
+        "Weather"
     ]
 }

--- a/data/tooltalk/AccountTools-Calendar-Weather-RegisterUser-0.json
+++ b/data/tooltalk/AccountTools-Calendar-Weather-RegisterUser-0.json
@@ -3,15 +3,11 @@
     "conversation_id": "12b94bad-5896-4282-922b-c51604cd05ef",
     "suites_used": [
         "AccountTools",
-        "Calendar",
-        "Weather"
+        "Calendar"
     ],
     "apis_used": [
-        "QueryUser",
-        "RegisterUser",
         "CreateEvent",
-        "QueryCalendar",
-        "CurrentWeather"
+        "RegisterUser"
     ],
     "scenario": "The user wants to register a new account and create a meeting event with another user. They use RegisterUser to sign up with their username, password, email, name, and phone. They receive a session_token and their account information. They then use QueryUser to search for the username of the other user they want to invite to the meeting. They find the user and use CreateEvent to create a meeting event with the name, description, start_time, end_time, and attendees. They receive an event_id on success. They then use QueryCalendar to check their calendar for any conflicts or overlaps with the new event. They see that there are no conflicts and use CurrentWeather to check the weather of the location where the meeting is to be held. They see that it is sunny and warm.",
     "user": {
@@ -243,5 +239,17 @@
             "role": "assistant",
             "text": "No problem. Have a great day!"
         }
+    ],
+    "intended_apis_used": [
+        "QueryUser",
+        "RegisterUser",
+        "CreateEvent",
+        "QueryCalendar",
+        "CurrentWeather"
+    ],
+    "intended_suites_used": [
+        "AccountTools",
+        "Calendar",
+        "Weather"
     ]
 }

--- a/data/tooltalk/AccountTools-Calendar-Weather-RegisterUser-0.json
+++ b/data/tooltalk/AccountTools-Calendar-Weather-RegisterUser-0.json
@@ -239,17 +239,5 @@
             "role": "assistant",
             "text": "No problem. Have a great day!"
         }
-    ],
-    "intended_apis_used": [
-        "QueryUser",
-        "RegisterUser",
-        "CreateEvent",
-        "QueryCalendar",
-        "CurrentWeather"
-    ],
-    "intended_suites_used": [
-        "AccountTools",
-        "Calendar",
-        "Weather"
     ]
 }

--- a/data/tooltalk/AccountTools-Email-Reminder-ChangePassword-1.json
+++ b/data/tooltalk/AccountTools-Email-Reminder-ChangePassword-1.json
@@ -204,16 +204,5 @@
             "role": "user",
             "text": "Nope, that's it. Thanks!"
         }
-    ],
-    "intended_apis_used": [
-        "GetAccountInformation",
-        "LogoutUser",
-        "UpdateAccountInformation",
-        "UserLogin"
-    ],
-    "intended_suites_used": [
-        "AccountTools",
-        "Email",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/AccountTools-Email-Reminder-ChangePassword-1.json
+++ b/data/tooltalk/AccountTools-Email-Reminder-ChangePassword-1.json
@@ -2,15 +2,14 @@
     "name": "AccountTools-Email-Reminder-ChangePassword-1",
     "conversation_id": "acf76d08-c7a5-4b5d-97f1-01f6eb13046e",
     "suites_used": [
-        "AccountTools",
-        "Email",
-        "Reminder"
+        "AccountTools"
     ],
     "apis_used": [
-        "GetAccountInformation",
-        "LogoutUser",
         "UpdateAccountInformation",
-        "UserLogin"
+        "LogoutUser",
+        "GetAccountInformation",
+        "UserLogin",
+        "ChangePassword"
     ],
     "scenario": "The user wants to update their account information and change their password. They log in with their current password (UserLogin). They go to their account settings and enter their new email, phone number, and password (UpdateAccountInformation). They log out of their account (LogoutUser). They log in with their new password (UserLogin). They verify that their account information has been updated (GetAccountInformation).",
     "user": {
@@ -205,5 +204,16 @@
             "role": "user",
             "text": "Nope, that's it. Thanks!"
         }
+    ],
+    "intended_apis_used": [
+        "GetAccountInformation",
+        "LogoutUser",
+        "UpdateAccountInformation",
+        "UserLogin"
+    ],
+    "intended_suites_used": [
+        "AccountTools",
+        "Email",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Alarm-Calendar-Email-DeleteAlarm-1.json
+++ b/data/tooltalk/Alarm-Calendar-Email-DeleteAlarm-1.json
@@ -3,16 +3,12 @@
     "conversation_id": "ea9c44d7-cc68-4474-8eeb-f753b2888af2",
     "suites_used": [
         "Alarm",
-        "Calendar",
-        "Email"
+        "Calendar"
     ],
     "apis_used": [
+        "DeleteAlarm",
         "AddAlarm",
-        "CreateEvent",
-        "DeleteEvent",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
+        "QueryCalendar"
     ],
     "scenario": "The user has a reminder on their calendar to buy a birthday gift for their friend at 3:00 PM (CreateEvent). The user sets an alarm for 2:30 PM to make sure they don't forget (AddAlarm). The user then queries their calendar for any other events happening today (QueryCalendar) and sees that they have a dentist appointment at 4:00 PM (CreateEvent). The user realizes that they don't have enough time to buy the gift and go to the dentist, so they decide to cancel the dentist appointment (DeleteEvent). The user then calls the dentist to reschedule and receives a confirmation email (SendEmail). The user searches their inbox for the email and adds the new appointment to their calendar (SearchInbox + CreateEvent).",
     "user": {
@@ -135,5 +131,18 @@
             "role": "user",
             "text": "Thanks!"
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm",
+        "CreateEvent",
+        "DeleteEvent",
+        "QueryCalendar",
+        "SearchInbox",
+        "SendEmail"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Calendar",
+        "Email"
     ]
 }

--- a/data/tooltalk/Alarm-Calendar-Email-DeleteAlarm-1.json
+++ b/data/tooltalk/Alarm-Calendar-Email-DeleteAlarm-1.json
@@ -131,18 +131,5 @@
             "role": "user",
             "text": "Thanks!"
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm",
-        "CreateEvent",
-        "DeleteEvent",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Calendar",
-        "Email"
     ]
 }

--- a/data/tooltalk/Alarm-Calendar-Messages-AddAlarm-1.json
+++ b/data/tooltalk/Alarm-Calendar-Messages-AddAlarm-1.json
@@ -169,13 +169,5 @@
             "role": "user",
             "text": "Thanks!"
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Calendar",
-        "Messages"
     ]
 }

--- a/data/tooltalk/Alarm-Calendar-Messages-AddAlarm-1.json
+++ b/data/tooltalk/Alarm-Calendar-Messages-AddAlarm-1.json
@@ -4,10 +4,14 @@
     "suites_used": [
         "Alarm",
         "Calendar",
+        "Email",
         "Messages"
     ],
     "apis_used": [
-        "AddAlarm"
+        "SendMessage",
+        "CreateEvent",
+        "AddAlarm",
+        "SearchInbox"
     ],
     "scenario": "The user wants to set an alarm for a flight they have to catch at 6:00 PM. They use AddAlarm to create an alarm for 4:00 PM. They also use CreateEvent to add the flight details to their calendar, with the name, description, start_time, end_time, and location. They then use SearchMessages to look for the confirmation email from the airline, with the query \"flight\", sender \"airline@example.com\", and start_date and end_date as today's date. They find the email and check the flight number, boarding time, and gate number. They also use SendMessage to send a message to their friend who is picking them up at the destination, with the message containing their flight information and arrival time.",
     "user": {
@@ -165,5 +169,13 @@
             "role": "user",
             "text": "Thanks!"
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Calendar",
+        "Messages"
     ]
 }

--- a/data/tooltalk/Alarm-Messages-Reminder-GetReminder-2.json
+++ b/data/tooltalk/Alarm-Messages-Reminder-GetReminder-2.json
@@ -133,17 +133,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm",
-        "SearchMessages",
-        "SendMessage",
-        "CompleteReminder",
-        "GetReminders"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Messages",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Alarm-Messages-Reminder-GetReminder-2.json
+++ b/data/tooltalk/Alarm-Messages-Reminder-GetReminder-2.json
@@ -3,15 +3,12 @@
     "conversation_id": "912ddbc2-663b-4fbd-ac9c-e54d572bdfac",
     "suites_used": [
         "Alarm",
-        "Messages",
         "Reminder"
     ],
     "apis_used": [
-        "AddAlarm",
-        "SearchMessages",
-        "SendMessage",
+        "GetReminders",
         "CompleteReminder",
-        "GetReminders"
+        "AddAlarm"
     ],
     "scenario": "The user wants to study for an exam and has a reminder to review the notes and practice the exercises (GetReminders). They see that the reminder has a due date of tomorrow, which is the day of the exam. They decide to complete the reminder today and mark it as done (CompleteReminder). They then use a note-taking app to access their notes and a quiz app to practice the exercises. They spend two hours studying and then take a break. They send a message to their study group to ask how they are doing and share some tips (SendMessage). They also search for messages from their instructor to see if there are any updates or clarifications on the exam (SearchMessages). They then set an alarm for the next morning to wake up early and review the notes one more time (AddAlarm).",
     "user": {
@@ -136,5 +133,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm",
+        "SearchMessages",
+        "SendMessage",
+        "CompleteReminder",
+        "GetReminders"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Messages",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Alarm-Reminder-Weather-AddReminder-1.json
+++ b/data/tooltalk/Alarm-Reminder-Weather-AddReminder-1.json
@@ -2,15 +2,12 @@
     "name": "Alarm-Reminder-Weather-AddReminder-1",
     "conversation_id": "1e1ad400-b86b-4e7c-9809-0351c22d4b6d",
     "suites_used": [
-        "Alarm",
         "Reminder",
         "Weather"
     ],
     "apis_used": [
-        "AddReminder",
-        "CompleteReminder",
-        "GetReminders",
         "CurrentWeather",
+        "AddReminder",
         "HistoricWeather"
     ],
     "scenario": "The user wants to set a reminder to pay their electricity bill before the due date. They also want to compare the current weather and the historic weather of their location to see if they are using more or less electricity than usual. They use the AddReminder API to create a reminder with the task \"Pay electricity bill\" and the due date \"2021-12-15 23:59:59\". They then use the CurrentWeather API to get the current weather of their location. They see that the temperature is 15 degrees Celsius and the humidity is 60%. They then use the HistoricWeather API to get the weather data of their location for the same date last year. They see that the temperature was 10 degrees Celsius and the humidity was 40%. They conclude that they are using more electricity this year because of the higher temperature and humidity. They then use the GetReminders API to get a list of all their reminders. They see that they have another reminder to pay their rent on the same day. They use the CompleteReminder API to mark that reminder as done, since they have already paid their rent online.",
@@ -118,5 +115,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "AddReminder",
+        "CompleteReminder",
+        "GetReminders",
+        "CurrentWeather",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Alarm-Reminder-Weather-AddReminder-1.json
+++ b/data/tooltalk/Alarm-Reminder-Weather-AddReminder-1.json
@@ -115,17 +115,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "AddReminder",
-        "CompleteReminder",
-        "GetReminders",
-        "CurrentWeather",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Alarm-Reminder-Weather-DeleteAlarm-2.json
+++ b/data/tooltalk/Alarm-Reminder-Weather-DeleteAlarm-2.json
@@ -121,18 +121,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm",
-        "DeleteAlarm",
-        "AddReminder",
-        "CompleteReminder",
-        "CurrentWeather",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Alarm-Reminder-Weather-DeleteAlarm-2.json
+++ b/data/tooltalk/Alarm-Reminder-Weather-DeleteAlarm-2.json
@@ -7,12 +7,9 @@
         "Weather"
     ],
     "apis_used": [
-        "AddAlarm",
-        "DeleteAlarm",
-        "AddReminder",
-        "CompleteReminder",
         "CurrentWeather",
-        "ForecastWeather"
+        "AddReminder",
+        "AddAlarm"
     ],
     "scenario": "The user is a freelancer who works from home. They set an alarm for 9:00 AM using AddAlarm. They also add a reminder to finish a project by noon using AddReminder. They check the current weather of their city using CurrentWeather and see that it is cloudy and windy. They decide to work indoors and add another reminder to order lunch using AddReminder. They wake up to the alarm and complete the first reminder using CompleteReminder. They check the forecast weather of their city using ForecastWeather and see that it will be sunny and warm in the afternoon. They decide to go for a walk after work and add another reminder to apply sunscreen using AddReminder. They delete the alarm using DeleteAlarm and start working on the project.",
     "user": {
@@ -124,5 +121,18 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm",
+        "DeleteAlarm",
+        "AddReminder",
+        "CompleteReminder",
+        "CurrentWeather",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Alarm-Reminder-Weather-FindAlarm-2.json
+++ b/data/tooltalk/Alarm-Reminder-Weather-FindAlarm-2.json
@@ -108,19 +108,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm",
-        "DeleteAlarm",
-        "FindAlarms",
-        "AddReminder",
-        "CompleteReminder",
-        "GetReminders",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Alarm-Reminder-Weather-FindAlarm-2.json
+++ b/data/tooltalk/Alarm-Reminder-Weather-FindAlarm-2.json
@@ -2,17 +2,11 @@
     "name": "Alarm-Reminder-Weather-FindAlarm-2",
     "conversation_id": "1941f3b6-2ce7-431a-ba30-b1e5b5d0019d",
     "suites_used": [
-        "Alarm",
         "Reminder",
         "Weather"
     ],
     "apis_used": [
-        "AddAlarm",
-        "DeleteAlarm",
-        "FindAlarms",
         "AddReminder",
-        "CompleteReminder",
-        "GetReminders",
         "ForecastWeather"
     ],
     "scenario": "The user wants to do some gardening on a sunny day. They want to get the weather forecast for the next three days (ForecastWeather) and choose the best day to do it. They want to set a reminder to buy some seeds and fertilizer (AddReminder). They also want to set an alarm for the morning of the chosen day (AddAlarm). They want to check their existing reminders (GetReminders) and complete any that are related to gardening (CompleteReminder). They want to delete any alarms that are not needed for the chosen day (FindAlarms + DeleteAlarm).",
@@ -114,5 +108,19 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm",
+        "DeleteAlarm",
+        "FindAlarms",
+        "AddReminder",
+        "CompleteReminder",
+        "GetReminders",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Email-Reminder-GetReminder-1.json
+++ b/data/tooltalk/Calendar-Email-Reminder-GetReminder-1.json
@@ -153,18 +153,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CreateEvent",
-        "ModifyEvent",
-        "SearchInbox",
-        "SendEmail",
-        "AddReminder",
-        "GetReminders"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Email",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Email-Reminder-GetReminder-1.json
+++ b/data/tooltalk/Calendar-Email-Reminder-GetReminder-1.json
@@ -7,12 +7,10 @@
         "Reminder"
     ],
     "apis_used": [
-        "CreateEvent",
-        "ModifyEvent",
-        "SearchInbox",
         "SendEmail",
+        "CreateEvent",
         "AddReminder",
-        "GetReminders"
+        "SearchInbox"
     ],
     "scenario": "The user wants to plan a trip to Hawaii with their family. They have a reminder to book the flights by the end of the week (GetReminders). They search their inbox for any emails from travel agencies or airlines that offer discounts or deals (SearchInbox). They find one email from a travel agency that has a package deal for flights and hotels. They reply to the email to inquire about the availability and price (SendEmail). They also create a new event on their calendar for the tentative dates of the trip (CreateEvent). They then add a new reminder to pack their bags two days before the trip (AddReminder). They also modify the reminder to book the flights to include the travel agency's contact information (ModifyEvent).",
     "user": {
@@ -155,5 +153,18 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CreateEvent",
+        "ModifyEvent",
+        "SearchInbox",
+        "SendEmail",
+        "AddReminder",
+        "GetReminders"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Email",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Email-Reminder-SendEmail-2.json
+++ b/data/tooltalk/Calendar-Email-Reminder-SendEmail-2.json
@@ -141,17 +141,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "ModifyEvent",
-        "QueryCalendar",
-        "SendEmail",
-        "AddReminder",
-        "CompleteReminder"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Email",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Email-Reminder-SendEmail-2.json
+++ b/data/tooltalk/Calendar-Email-Reminder-SendEmail-2.json
@@ -2,16 +2,15 @@
     "name": "Calendar-Email-Reminder-SendEmail-2",
     "conversation_id": "c32379dc-2bb9-4eab-8b07-5471932ba605",
     "suites_used": [
+        "AccountTools",
         "Calendar",
-        "Email",
-        "Reminder"
+        "Email"
     ],
     "apis_used": [
-        "ModifyEvent",
-        "QueryCalendar",
         "SendEmail",
-        "AddReminder",
-        "CompleteReminder"
+        "ModifyEvent",
+        "QueryUser",
+        "QueryCalendar"
     ],
     "scenario": "The user wants to modify an existing event with the name \"Birthday party\", the type \"event\", the description \"Celebrate my birthday with friends and family\", the start time \"2021-01-16 18:00:00\", the end time \"2021-01-16 22:00:00\", and the location \"My house\" (QueryCalendar). They decide to change the start time to \"2021-01-16 19:00:00\", the end time to \"2021-01-16 23:00:00\", and the location to \"The restaurant\" (ModifyEvent). They then send an email to the attendees with the subject \"Event update\", the body \"Hi, I have made some changes to the event details for my birthday party. Please see the new information below and let me know if you can still make it.\", and the to addresses \"user@domain.com\", \"friend1@domain.com\", \"friend2@domain.com\", and \"family@domain.com\" (SendEmail). They then add a reminder with the task \"Make reservation at the restaurant\" and the due date \"2021-01-15 12:00:00\" (AddReminder). They then complete the reminder with the reminder_id returned from the previous call (CompleteReminder).",
     "user": {
@@ -142,5 +141,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "ModifyEvent",
+        "QueryCalendar",
+        "SendEmail",
+        "AddReminder",
+        "CompleteReminder"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Email",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Reminder-AddReminder-1.json
+++ b/data/tooltalk/Calendar-Messages-Reminder-AddReminder-1.json
@@ -2,16 +2,13 @@
     "name": "Calendar-Messages-Reminder-AddReminder-1",
     "conversation_id": "35b5029c-e42d-429a-b0cc-d0be8a73ef87",
     "suites_used": [
-        "Calendar",
-        "Messages",
         "Reminder"
     ],
     "apis_used": [
-        "QueryCalendar",
-        "SendMessage",
-        "AddReminder",
+        "GetReminders",
         "CompleteReminder",
-        "GetReminders"
+        "DeleteReminder",
+        "AddReminder"
     ],
     "scenario": "The user wants to check their calendar for any upcoming events and reminders. They first query their calendar for the events that occur in the next week (QueryCalendar). They then get a list of their reminders that are due in the next week (GetReminders). They see that they have a reminder to pay their rent by the end of the month, and they decide to do it right away (CompleteReminder). They also see that they have an event for a birthday party on the weekend, and they want to buy a gift for the host. They add a reminder to order a gift online by Friday (AddReminder). They then send a message to the host to RSVP and ask for their address (SendMessage).",
     "user": {
@@ -184,5 +181,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "QueryCalendar",
+        "SendMessage",
+        "AddReminder",
+        "CompleteReminder",
+        "GetReminders"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Messages",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Reminder-AddReminder-1.json
+++ b/data/tooltalk/Calendar-Messages-Reminder-AddReminder-1.json
@@ -181,17 +181,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "QueryCalendar",
-        "SendMessage",
-        "AddReminder",
-        "CompleteReminder",
-        "GetReminders"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Messages",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Reminder-QueryCalendar-2.json
+++ b/data/tooltalk/Calendar-Messages-Reminder-QueryCalendar-2.json
@@ -2,14 +2,11 @@
     "name": "Calendar-Messages-Reminder-QueryCalendar-2",
     "conversation_id": "9a054cc8-a79e-4f1c-8495-56f1c75357ae",
     "suites_used": [
-        "Calendar",
-        "Messages",
-        "Reminder"
+        "Calendar"
     ],
     "apis_used": [
         "ModifyEvent",
-        "QueryCalendar",
-        "SendMessage"
+        "QueryCalendar"
     ],
     "scenario": "The user wants to modify an event they created earlier to accommodate a new attendee. They query their calendar to find the event id of the event they want to modify (QueryCalendar). They then modify the event by adding the new attendee to the list of attendees and changing the location to a larger venue (ModifyEvent). They also send a message to the original attendees of the event to notify them of the changes and introduce the new attendee (SendMessage). They then query their calendar again to see if the modified event conflicts with any other events or reminders they have (QueryCalendar). They find that they have a reminder for a task that is due on the same day as the event. They decide to postpone the task and change the due date of the reminder (ModifyReminder).",
     "user": {
@@ -95,5 +92,15 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "ModifyEvent",
+        "QueryCalendar",
+        "SendMessage"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Messages",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Reminder-QueryCalendar-2.json
+++ b/data/tooltalk/Calendar-Messages-Reminder-QueryCalendar-2.json
@@ -92,15 +92,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "ModifyEvent",
-        "QueryCalendar",
-        "SendMessage"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Messages",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Weather-DeleteEvent-0.json
+++ b/data/tooltalk/Calendar-Messages-Weather-DeleteEvent-0.json
@@ -3,15 +3,12 @@
     "conversation_id": "259cb6f6-e8a8-4edc-a1ea-6e4dcd2d6335",
     "suites_used": [
         "Calendar",
-        "Messages",
-        "Weather"
+        "Messages"
     ],
     "apis_used": [
-        "DeleteEvent",
-        "QueryCalendar",
-        "SearchMessages",
         "SendMessage",
-        "CurrentWeather"
+        "DeleteEvent",
+        "QueryCalendar"
     ],
     "scenario": "The user wants to cancel a meeting with a client due to a personal emergency. They first check their calendar for the event details (QueryCalendar). They then delete the event from their calendar (DeleteEvent). They also send a message to the client explaining the situation and apologizing for the inconvenience (SendMessage). They then search for any previous messages from the client to see if they have any alternative contacts or preferences (SearchMessages). They also check the weather of the client's location to see if there are any adverse conditions that might affect their rescheduling (CurrentWeather).",
     "user": {
@@ -108,5 +105,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "DeleteEvent",
+        "QueryCalendar",
+        "SearchMessages",
+        "SendMessage",
+        "CurrentWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Messages",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Weather-DeleteEvent-0.json
+++ b/data/tooltalk/Calendar-Messages-Weather-DeleteEvent-0.json
@@ -105,17 +105,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "DeleteEvent",
-        "QueryCalendar",
-        "SearchMessages",
-        "SendMessage",
-        "CurrentWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Messages",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Weather-SendMessage-0.json
+++ b/data/tooltalk/Calendar-Messages-Weather-SendMessage-0.json
@@ -3,14 +3,12 @@
     "conversation_id": "d18f4ea6-bb25-4ebc-a0b9-1e0162894f72",
     "suites_used": [
         "Calendar",
-        "Messages",
-        "Weather"
+        "Weather",
+        "Messages"
     ],
     "apis_used": [
         "CreateEvent",
-        "SearchMessages",
         "SendMessage",
-        "CurrentWeather",
         "ForecastWeather"
     ],
     "scenario": "The user wants to plan a trip with their friends to a ski resort. They first check the current weather of the resort using CurrentWeather. They see that it is snowing and the temperature is below freezing. They then check the forecast for the next 3 days using ForecastWeather. They see that the snow will continue and the temperature will remain low. They decide that it is a good time to go skiing and create an event on their calendar using CreateEvent. They set the event type to 'event', the name to 'Ski Trip', the description to 'A fun weekend at the ski resort', the start time to '2021-01-15 08:00:00', the end time to '2021-01-17 18:00:00', and the location to 'Snowy Mountain Resort'. They then invite their friends to the event by adding their usernames to the attendees parameter. They also send a message to their friends using SendMessage to let them know about the event and ask them to confirm their attendance. They wait for their friends to reply and check their messages using SearchMessages with the query 'Ski Trip' and the sender as their username.",
@@ -155,5 +153,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CreateEvent",
+        "SearchMessages",
+        "SendMessage",
+        "CurrentWeather",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Messages",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Weather-SendMessage-0.json
+++ b/data/tooltalk/Calendar-Messages-Weather-SendMessage-0.json
@@ -153,17 +153,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CreateEvent",
-        "SearchMessages",
-        "SendMessage",
-        "CurrentWeather",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Messages",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Weather-SendMessage-1.json
+++ b/data/tooltalk/Calendar-Messages-Weather-SendMessage-1.json
@@ -3,14 +3,11 @@
     "conversation_id": "068dbfba-0b2b-42b2-835e-f068a3e545ca",
     "suites_used": [
         "Calendar",
-        "Messages",
-        "Weather"
+        "Messages"
     ],
     "apis_used": [
         "CreateEvent",
         "ModifyEvent",
-        "QueryCalendar",
-        "SearchMessages",
         "SendMessage"
     ],
     "scenario": "The user is a manager of a team and needs to schedule a meeting with their employees. They first query their calendar using QueryCalendar to see their availability for the next week. They provide the start_time as '2021-01-11 00:00:00' and the end_time as '2021-01-17 23:59:59'. They see that they have no events on Wednesday from 10:00 to 11:00. They then create an event using CreateEvent with the event type as 'meeting', the name as 'Weekly Update', the description as 'Discuss the progress and challenges of the current project', the start_time as '2021-01-13 10:00:00', the end_time as '2021-01-13 11:00:00', and the location as 'Zoom'. They then add their employees' usernames to the attendees parameter. They also send a message to their employees using SendMessage to remind them of the meeting and ask them to prepare their reports. They receive a message from one of their employees using SearchMessages with the sender as the employee's username. The employee informs them that they have a conflict and requests to reschedule the meeting. The user agrees and modifies the event using ModifyEvent. They change the start_time to '2021-01-13 14:00:00' and the end_time to '2021-01-13 15:00:00'. They also send a message to their employees using SendMessage to notify them of the change and apologize for the inconvenience.",
@@ -175,5 +172,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CreateEvent",
+        "ModifyEvent",
+        "QueryCalendar",
+        "SearchMessages",
+        "SendMessage"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Messages",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Messages-Weather-SendMessage-1.json
+++ b/data/tooltalk/Calendar-Messages-Weather-SendMessage-1.json
@@ -172,17 +172,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CreateEvent",
-        "ModifyEvent",
-        "QueryCalendar",
-        "SearchMessages",
-        "SendMessage"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Messages",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-CompleteReminder-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-CompleteReminder-1.json
@@ -2,16 +2,14 @@
     "name": "Calendar-Reminder-Weather-CompleteReminder-1",
     "conversation_id": "90d1b411-80aa-467c-883b-a9e363912c05",
     "suites_used": [
-        "Calendar",
         "Reminder",
         "Weather"
     ],
     "apis_used": [
-        "CreateEvent",
-        "AddReminder",
-        "CompleteReminder",
         "CurrentWeather",
-        "HistoricWeather"
+        "GetReminders",
+        "CompleteReminder",
+        "AddReminder"
     ],
     "scenario": "The user has a reminder to buy a birthday gift for their friend by Monday (AddReminder). They want to see what the weather is like in their friend's city, so they can choose an appropriate gift (CurrentWeather). They see that the weather is cold and snowy, so they decide to buy a warm scarf and gloves. They create an event on their calendar to go to the mall on Saturday (CreateEvent). They also want to compare the weather in their friend's city to their own, so they use the HistoricWeather API to get the average temperature and precipitation for both locations in the past month (HistoricWeather). They see that their friend's city is much colder and wetter than theirs, so they feel good about their gift choice. They buy the gift on Saturday and complete the reminder (CompleteReminder).",
     "user": {
@@ -128,5 +126,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CreateEvent",
+        "AddReminder",
+        "CompleteReminder",
+        "CurrentWeather",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-CompleteReminder-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-CompleteReminder-1.json
@@ -126,17 +126,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CreateEvent",
-        "AddReminder",
-        "CompleteReminder",
-        "CurrentWeather",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-CreateEvent-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-CreateEvent-1.json
@@ -7,9 +7,11 @@
         "Weather"
     ],
     "apis_used": [
-        "CreateEvent",
         "AddReminder",
-        "CurrentWeather"
+        "CompleteReminder",
+        "GetReminders",
+        "CreateEvent",
+        "ForecastWeather"
     ],
     "scenario": "The user wants to create a reminder event for their anniversary with their partner. They first use the CurrentWeather API with their partner's location to get the current weather of their partner's city (CurrentWeather). They see that it is raining and cold there, so they decide to send them a warm and cozy gift. They then create a reminder event with the name \"Anniversary\", the event type as \"reminder\", the description as \"Send gift to partner\", and the start time and end time as the same date and time, which is one week before their anniversary (CreateEvent). They also want to book a flight and a hotel for their anniversary trip, which they plan to take two weeks after their anniversary. They use a third-party API to search for flights and hotels based on their destination, budget, and preferences (SearchFlightsAndHotels). They find a suitable flight and hotel and book them using another third-party API (BookFlightAndHotel). They then create two more events on their calendar, one for the flight departure and arrival, and one for the hotel check-in and check-out, with the corresponding names, event types, descriptions, start times, end times, and locations (CreateEvent x 2). They also want to set a reminder for themselves to pack their bags and print their tickets. They add a reminder with the task \"Pack and print\" and the due date as one day before their flight (AddReminder).",
     "user": {
@@ -171,5 +173,15 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CreateEvent",
+        "AddReminder",
+        "CurrentWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-CreateEvent-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-CreateEvent-1.json
@@ -173,15 +173,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CreateEvent",
-        "AddReminder",
-        "CurrentWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-DeleteEvent-0.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-DeleteEvent-0.json
@@ -155,18 +155,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CreateEvent",
-        "DeleteEvent",
-        "QueryCalendar",
-        "AddReminder",
-        "DeleteReminder",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-DeleteEvent-0.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-DeleteEvent-0.json
@@ -3,16 +3,13 @@
     "conversation_id": "3594e114-eb95-4d4c-a368-98a18a7db1a9",
     "suites_used": [
         "Calendar",
-        "Reminder",
-        "Weather"
+        "Reminder"
     ],
     "apis_used": [
-        "CreateEvent",
+        "GetReminders",
         "DeleteEvent",
         "QueryCalendar",
-        "AddReminder",
-        "DeleteReminder",
-        "ForecastWeather"
+        "DeleteReminder"
     ],
     "scenario": "The user is planning a trip to Paris and wants to check the weather before booking their flights and hotels. They use ForecastWeather to get the 3-day forecast of Paris and see that it is sunny and mild. They then use CreateEvent to add a flight reservation event to their calendar, with the name, start_time, end_time, and location of the flight. They also use CreateEvent to add a hotel reservation event to their calendar, with the name, start_time, end_time, and location of the hotel. They then use AddReminder to create a reminder to pack their suitcase, with the task and due_date. They also use AddReminder to create a reminder to check in online, with the task and due_date. However, they later receive an email that their flight has been cancelled due to a strike. They use DeleteEvent to delete the flight reservation event from their calendar. They also use DeleteEvent to delete the hotel reservation event from their calendar. They then use DeleteReminder to delete the reminder to pack their suitcase. They also use DeleteReminder to delete the reminder to check in online. They then use QueryCalendar to see if they have any other events planned for the next week.",
     "user": {
@@ -158,5 +155,18 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CreateEvent",
+        "DeleteEvent",
+        "QueryCalendar",
+        "AddReminder",
+        "DeleteReminder",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-DeleteReminder-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-DeleteReminder-1.json
@@ -141,17 +141,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CreateEvent",
-        "ModifyEvent",
-        "AddReminder",
-        "DeleteReminder",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-DeleteReminder-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-DeleteReminder-1.json
@@ -3,15 +3,13 @@
     "conversation_id": "cf1b6080-50b2-41fd-be5f-e9adfbdc2a65",
     "suites_used": [
         "Calendar",
-        "Reminder",
-        "Weather"
+        "Reminder"
     ],
     "apis_used": [
+        "GetReminders",
         "CreateEvent",
-        "ModifyEvent",
-        "AddReminder",
         "DeleteReminder",
-        "ForecastWeather"
+        "AddReminder"
     ],
     "scenario": "The user is planning a trip to Paris next week. They want to create an event for their flight departure and arrival (CreateEvent). They also want to create a reminder to pack their passport and other essentials (AddReminder). They want to see the weather forecast for Paris to decide what clothes to bring (ForecastWeather). They see that it will be sunny and warm, so they want to modify their reminder to include sunscreen and sunglasses (ModifyEvent). They also want to delete the reminder for their dentist appointment that they had scheduled for the same week (DeleteReminder).",
     "user": {
@@ -143,5 +141,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CreateEvent",
+        "ModifyEvent",
+        "AddReminder",
+        "DeleteReminder",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-ModifyEvent-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-ModifyEvent-1.json
@@ -3,16 +3,12 @@
     "conversation_id": "e32a3a5c-ce4e-4ef6-9a95-fa8cf3bcfb21",
     "suites_used": [
         "Calendar",
-        "Reminder",
-        "Weather"
+        "Reminder"
     ],
     "apis_used": [
-        "ModifyEvent",
-        "QueryCalendar",
         "AddReminder",
-        "CompleteReminder",
-        "GetReminders",
-        "CurrentWeather"
+        "ModifyEvent",
+        "QueryCalendar"
     ],
     "scenario": "The user is a busy professional who has a lot of meetings and deadlines. They want to query their calendar for the next week to see their schedule (QueryCalendar). They see that they have a meeting with a client on Monday at 10 am, but they also have a reminder to finish a report by 11 am (GetReminders). They decide to reschedule the meeting to Tuesday at 9 am, so they modify the event on their calendar (ModifyEvent). They also want to check the weather for Monday to see if they need an umbrella (CurrentWeather). They see that it will be rainy, so they add a reminder to bring an umbrella (AddReminder). They also want to complete the reminder for the report, so they mark it as done (CompleteReminder).",
     "user": {
@@ -134,5 +130,18 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "ModifyEvent",
+        "QueryCalendar",
+        "AddReminder",
+        "CompleteReminder",
+        "GetReminders",
+        "CurrentWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-ModifyEvent-1.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-ModifyEvent-1.json
@@ -130,18 +130,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "ModifyEvent",
-        "QueryCalendar",
-        "AddReminder",
-        "CompleteReminder",
-        "GetReminders",
-        "CurrentWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-QueryCalendar-0.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-QueryCalendar-0.json
@@ -3,15 +3,12 @@
     "conversation_id": "5077c89c-8134-4562-bd5f-805fa9678c33",
     "suites_used": [
         "Calendar",
-        "Reminder",
-        "Weather"
+        "Email"
     ],
     "apis_used": [
+        "SendEmail",
         "ModifyEvent",
-        "QueryCalendar",
-        "AddReminder",
-        "CurrentWeather",
-        "ForecastWeather"
+        "QueryCalendar"
     ],
     "scenario": "The user wants to plan a trip to Paris with their friends. They want to check their calendar for any events that might conflict with their travel dates (QueryCalendar). They find that they have a meeting on the first day of their trip, so they decide to modify the event to a later date (ModifyEvent). They also want to create a reminder to book their flight tickets (AddReminder). They then want to see the weather forecast for Paris to decide what to pack (ForecastWeather). They also want to compare the current weather in Paris with their home city (CurrentWeather + CurrentWeather).",
     "user": {
@@ -183,5 +180,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "ModifyEvent",
+        "QueryCalendar",
+        "AddReminder",
+        "CurrentWeather",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Calendar",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Calendar-Reminder-Weather-QueryCalendar-0.json
+++ b/data/tooltalk/Calendar-Reminder-Weather-QueryCalendar-0.json
@@ -180,17 +180,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "ModifyEvent",
-        "QueryCalendar",
-        "AddReminder",
-        "CurrentWeather",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Calendar",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Messages-Reminder-DeleteReminder-1.json
+++ b/data/tooltalk/Email-Messages-Reminder-DeleteReminder-1.json
@@ -126,19 +126,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "SearchMessages",
-        "SendMessage",
-        "AddReminder",
-        "DeleteReminder",
-        "GetReminders"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Messages",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Email-Messages-Reminder-DeleteReminder-1.json
+++ b/data/tooltalk/Email-Messages-Reminder-DeleteReminder-1.json
@@ -3,17 +3,13 @@
     "conversation_id": "25921b06-9668-4be7-b28c-d8432db6103b",
     "suites_used": [
         "Email",
-        "Messages",
         "Reminder"
     ],
     "apis_used": [
-        "SearchInbox",
+        "GetReminders",
         "SendEmail",
-        "SearchMessages",
-        "SendMessage",
-        "AddReminder",
         "DeleteReminder",
-        "GetReminders"
+        "AddReminder"
     ],
     "scenario": "The user wants to delete a reminder for a task that they have postponed to a later date. They first log in to the app and get a session_token. They then use the GetReminders API to see all their reminders. They find the reminder_id of the task they want to delete and use the DeleteReminder API to remove it. They then use the AddReminder API to create a new reminder for the same task, but with a different due_date. They then use the SearchInbox API to look for any emails from the task assigner, using the assigner's email address as the sender parameter and the task name as the query. They open the most recent email and use the SendEmail API to inform the assigner that they have postponed the task and updated the reminder. They then use the SearchMessages API to look for any messages from the assigner, using the assigner's username as the sender parameter and the task name as the query. They open the most recent message and use the SendMessage API to send an apology message that they have postponed the task and updated the reminder.",
     "user": {
@@ -130,5 +126,19 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchInbox",
+        "SendEmail",
+        "SearchMessages",
+        "SendMessage",
+        "AddReminder",
+        "DeleteReminder",
+        "GetReminders"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Messages",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Email-Messages-Reminder-SendEmail-2.json
+++ b/data/tooltalk/Email-Messages-Reminder-SendEmail-2.json
@@ -3,15 +3,12 @@
     "conversation_id": "bd463e6e-8fc7-43ac-95ce-e620ec3e013d",
     "suites_used": [
         "Email",
-        "Messages",
         "Reminder"
     ],
     "apis_used": [
-        "SearchInbox",
+        "GetReminders",
         "SendEmail",
-        "CompleteReminder",
-        "DeleteReminder",
-        "GetReminders"
+        "DeleteReminder"
     ],
     "scenario": "The user wants to delete some old emails and reminders that are no longer relevant. They search their inbox (SearchInbox) for emails older than a year using the query \"*\" and the end_date \"2019-10-01 00:00:00\". They select all the emails and delete them. They then search their reminders (GetReminders) for reminders that are past due. They find several reminders that they have already completed or cancelled. They delete each reminder (DeleteReminder) using the reminder_id. They then send an email (SendEmail) to their personal account with the subject \"Backup\" and the body \"Hi user, this is a backup of your important emails and reminders. Please keep it safe. Regards, user\". They attach a file containing the emails and reminders that they want to keep. They then complete the reminder (CompleteReminder) with the task \"Backup emails and reminders\" using the reminder_id. They then log out of their account.",
     "user": {
@@ -140,5 +137,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchInbox",
+        "SendEmail",
+        "CompleteReminder",
+        "DeleteReminder",
+        "GetReminders"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Messages",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Email-Messages-Reminder-SendEmail-2.json
+++ b/data/tooltalk/Email-Messages-Reminder-SendEmail-2.json
@@ -137,17 +137,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "CompleteReminder",
-        "DeleteReminder",
-        "GetReminders"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Messages",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Email-Messages-Reminder-SendMessage-2.json
+++ b/data/tooltalk/Email-Messages-Reminder-SendMessage-2.json
@@ -95,18 +95,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "SearchMessages",
-        "SendMessage",
-        "AddReminder",
-        "CompleteReminder"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Messages",
-        "Reminder"
     ]
 }

--- a/data/tooltalk/Email-Messages-Reminder-SendMessage-2.json
+++ b/data/tooltalk/Email-Messages-Reminder-SendMessage-2.json
@@ -2,17 +2,11 @@
     "name": "Email-Messages-Reminder-SendMessage-2",
     "conversation_id": "251a792c-c843-4a69-86b2-8161542b6987",
     "suites_used": [
-        "Email",
-        "Messages",
-        "Reminder"
+        "Messages"
     ],
     "apis_used": [
-        "SearchInbox",
-        "SendEmail",
         "SearchMessages",
-        "SendMessage",
-        "AddReminder",
-        "CompleteReminder"
+        "SendMessage"
     ],
     "scenario": "The user wants to send a message to their crush to ask them out. They first search their messages for any messages from their crush that contain the word \"like\" (SearchMessages). They find a message where their crush says they like the same movie as the user. They decide to use that as a conversation starter and send a message asking their crush if they want to watch the movie together (SendMessage). They then add a reminder to check their crush's reply in an hour (AddReminder). They then search their inbox for any emails from their crush that contain the word \"date\" (SearchInbox). They find an email where their crush invites them to a group date with some mutual friends. They reply with a yes and ask for the details (SendEmail). They then complete the reminder for checking their crush's reply (CompleteReminder). They see that their crush has agreed to watch the movie with them and send a message with a happy emoji (SendMessage).",
     "user": {
@@ -101,5 +95,18 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchInbox",
+        "SendEmail",
+        "SearchMessages",
+        "SendMessage",
+        "AddReminder",
+        "CompleteReminder"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Messages",
+        "Reminder"
     ]
 }

--- a/data/tooltalk/Email-Messages-Weather-SendMessage-2.json
+++ b/data/tooltalk/Email-Messages-Weather-SendMessage-2.json
@@ -2,15 +2,13 @@
     "name": "Email-Messages-Weather-SendMessage-2",
     "conversation_id": "41778a52-58b0-4ff1-aa42-e82eb8fe904b",
     "suites_used": [
-        "Email",
-        "Messages",
-        "Weather"
+        "Weather",
+        "Messages"
     ],
     "apis_used": [
         "SearchMessages",
         "SendMessage",
-        "ForecastWeather",
-        "HistoricWeather"
+        "ForecastWeather"
     ],
     "scenario": "The user wants to send a message to their online date to ask them out for a coffee. They want to impress them with their knowledge of the weather and suggest a nice place to meet. They want to check the historic weather of their date's location to see if there is a pattern or trend (HistoricWeather). They search for the weather of their date's location for the last 10 days (HistoricWeather). They find that the weather has been mostly sunny and warm. They also want to check the forecast weather of their date's location for the next 3 days to see if there is any chance of rain or snow (ForecastWeather). They find that the weather will be mostly cloudy and cool. They then search for messages from their date to see if they have mentioned any preferences or hobbies (SearchMessages). They search for messages with the sender \"date\" and the query \"coffee\" or \"hobby\" in the last week (SearchMessages). They find that their date likes coffee with almond milk and enjoys reading books. They then compose a message to their date with the weather information and a suggestion of a cozy cafe with a bookshelf (SendMessage).",
     "user": {
@@ -146,5 +144,16 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchMessages",
+        "SendMessage",
+        "ForecastWeather",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Messages",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Messages-Weather-SendMessage-2.json
+++ b/data/tooltalk/Email-Messages-Weather-SendMessage-2.json
@@ -144,16 +144,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchMessages",
-        "SendMessage",
-        "ForecastWeather",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Messages",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-CompleteReminder-2.json
+++ b/data/tooltalk/Email-Reminder-Weather-CompleteReminder-2.json
@@ -185,17 +185,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "AddReminder",
-        "CompleteReminder",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-CompleteReminder-2.json
+++ b/data/tooltalk/Email-Reminder-Weather-CompleteReminder-2.json
@@ -3,14 +3,16 @@
     "conversation_id": "f91e4a9d-7a72-4512-889c-5586378e1138",
     "suites_used": [
         "Email",
+        "AccountTools",
         "Reminder",
         "Weather"
     ],
     "apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "AddReminder",
+        "CurrentWeather",
         "CompleteReminder",
+        "GetReminders",
+        "SendEmail",
+        "QueryUser",
         "HistoricWeather"
     ],
     "scenario": "The user has a reminder to write a blog post about the weather trends in their city (AddReminder). They use the HistoricWeather API to get the weather data for the past month (HistoricWeather). They analyze the data and write the blog post. They then search their inbox for any emails from their editor or readers (SearchInbox). They reply to any relevant emails and ask for feedback on their post (SendEmail). They complete the reminder (CompleteReminder).",
@@ -183,5 +185,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchInbox",
+        "SendEmail",
+        "AddReminder",
+        "CompleteReminder",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-DeleteReminder-0.json
+++ b/data/tooltalk/Email-Reminder-Weather-DeleteReminder-0.json
@@ -134,18 +134,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "AddReminder",
-        "DeleteReminder",
-        "GetReminders",
-        "CurrentWeather"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-DeleteReminder-0.json
+++ b/data/tooltalk/Email-Reminder-Weather-DeleteReminder-0.json
@@ -3,16 +3,13 @@
     "conversation_id": "dff87b01-d181-4323-9955-655bc991ac4e",
     "suites_used": [
         "Email",
-        "Reminder",
-        "Weather"
+        "Reminder"
     ],
     "apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "AddReminder",
-        "DeleteReminder",
         "GetReminders",
-        "CurrentWeather"
+        "DeleteReminder",
+        "AddReminder",
+        "SearchInbox"
     ],
     "scenario": "The user wants to delete a reminder for a meeting that has been cancelled. They first want to check their inbox for any emails related to the meeting (SearchInbox). They find one email from the organizer confirming the cancellation and another email from a colleague asking for some feedback on a report (SearchInbox). They reply to the organizer with a polite message (SendEmail) and open the report attachment from the colleague. They decide to add a new reminder to review the report later (AddReminder). They then go to their list of reminders (GetReminders) and find the reminder for the cancelled meeting. They delete the reminder (DeleteReminder) and check the current weather (CurrentWeather) to see if they can go for a walk.",
     "user": {
@@ -137,5 +134,18 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchInbox",
+        "SendEmail",
+        "AddReminder",
+        "DeleteReminder",
+        "GetReminders",
+        "CurrentWeather"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-GetReminder-0.json
+++ b/data/tooltalk/Email-Reminder-Weather-GetReminder-0.json
@@ -179,16 +179,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchInbox",
-        "SendEmail",
-        "CompleteReminder",
-        "GetReminders"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-GetReminder-0.json
+++ b/data/tooltalk/Email-Reminder-Weather-GetReminder-0.json
@@ -3,14 +3,15 @@
     "conversation_id": "c135a231-484f-4e82-937e-d4853cb13eef",
     "suites_used": [
         "Email",
-        "Reminder",
-        "Weather"
+        "AccountTools",
+        "Reminder"
     ],
     "apis_used": [
-        "SearchInbox",
-        "SendEmail",
         "CompleteReminder",
-        "GetReminders"
+        "SearchInbox",
+        "GetReminders",
+        "SendEmail",
+        "QueryUser"
     ],
     "scenario": "The user wants to check their reminders for the day (GetReminders). They see that they have a reminder to send an email to their boss with a report attached (SendEmail). They search their inbox for the report that was sent to them by a colleague (SearchInbox). They find the email and download the attachment. They compose the email to their boss and send it (SendEmail). They then mark the reminder as complete (CompleteReminder).",
     "user": {
@@ -178,5 +179,16 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchInbox",
+        "SendEmail",
+        "CompleteReminder",
+        "GetReminders"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-SendEmail-2.json
+++ b/data/tooltalk/Email-Reminder-Weather-SendEmail-2.json
@@ -3,15 +3,13 @@
     "conversation_id": "3dac15e3-932a-4251-adf7-40220fa50eb1",
     "suites_used": [
         "Email",
-        "Reminder",
-        "Weather"
+        "Reminder"
     ],
     "apis_used": [
-        "SendEmail",
-        "AddReminder",
-        "CompleteReminder",
         "GetReminders",
-        "HistoricWeather"
+        "CompleteReminder",
+        "SendEmail",
+        "SearchInbox"
     ],
     "scenario": "The user wants to send an email to their colleague with some feedback on their presentation (SendEmail). They first watch the presentation video and take some notes. They then write an email with their feedback and suggestions. They also want to add a reminder to follow up with their colleague in a week (AddReminder). They then send the email (SendEmail). They then want to see if they have any other pending tasks, so they get a list of their reminders (GetReminders). They see that they have a reminder to complete a survey that is due today. They click on the link in the reminder and complete the survey. They then mark the reminder as complete (CompleteReminder). They also want to see how the weather has changed since they started working from home, so they query the historic weather data for the past month (HistoricWeather).",
     "user": {
@@ -169,5 +167,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SendEmail",
+        "AddReminder",
+        "CompleteReminder",
+        "GetReminders",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Email",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Email-Reminder-Weather-SendEmail-2.json
+++ b/data/tooltalk/Email-Reminder-Weather-SendEmail-2.json
@@ -167,17 +167,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SendEmail",
-        "AddReminder",
-        "CompleteReminder",
-        "GetReminders",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Email",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-AddReminder-1.json
+++ b/data/tooltalk/Messages-Reminder-Weather-AddReminder-1.json
@@ -139,16 +139,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "AddReminder",
-        "DeleteReminder",
-        "GetReminders",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-AddReminder-1.json
+++ b/data/tooltalk/Messages-Reminder-Weather-AddReminder-1.json
@@ -2,15 +2,12 @@
     "name": "Messages-Reminder-Weather-AddReminder-1",
     "conversation_id": "a2b446cd-055b-4173-9f4c-8b61dcab7b63",
     "suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
+        "Reminder"
     ],
     "apis_used": [
         "AddReminder",
-        "DeleteReminder",
         "GetReminders",
-        "ForecastWeather"
+        "DeleteReminder"
     ],
     "scenario": "The user wants to organize their tasks for the week. They want to add a reminder to finish their project report by Friday (AddReminder). They also want to add a reminder to call their mom on her birthday on Wednesday (AddReminder). They want to get a list of their reminders to see what else they need to do (GetReminders). They realize they have already completed one of their reminders, so they want to delete it (DeleteReminder). They also want to check the weather for the weekend to see if they can go hiking (ForecastWeather).",
     "user": {
@@ -142,5 +139,16 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "AddReminder",
+        "DeleteReminder",
+        "GetReminders",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Messages",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-CompleteReminder-1.json
+++ b/data/tooltalk/Messages-Reminder-Weather-CompleteReminder-1.json
@@ -2,13 +2,12 @@
     "name": "Messages-Reminder-Weather-CompleteReminder-1",
     "conversation_id": "8ab3dafb-ef39-48d8-aae4-22fddab8d489",
     "suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
+        "Reminder"
     ],
     "apis_used": [
-        "CompleteReminder",
-        "HistoricWeather"
+        "AddReminder",
+        "GetReminders",
+        "CompleteReminder"
     ],
     "scenario": "The user wants to complete a reminder to pay their rent. They want to see how much money they have left in their bank account (GetBalance). They see that they have enough to pay the rent, but not much more. They want to see if they can save some money by switching to a cheaper electricity plan (GetElectricityPlans). They see that there is a plan that offers a lower rate, but requires a 12-month contract. They want to see how the weather has changed in their area in the past year (HistoricWeather). They see that there have been more hot and cold days than usual, which means more electricity usage. They decide to stick with their current plan, which has no contract. They pay their rent online (PayRent). They complete the reminder to pay their rent (CompleteReminder).",
     "user": {
@@ -142,5 +141,14 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "CompleteReminder",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Messages",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-CompleteReminder-1.json
+++ b/data/tooltalk/Messages-Reminder-Weather-CompleteReminder-1.json
@@ -141,14 +141,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "CompleteReminder",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-ForecastWeather-1.json
+++ b/data/tooltalk/Messages-Reminder-Weather-ForecastWeather-1.json
@@ -2,15 +2,14 @@
     "name": "Messages-Reminder-Weather-ForecastWeather-1",
     "conversation_id": "45ede01b-e809-4144-8762-29672c53dcc6",
     "suites_used": [
-        "Messages",
         "Reminder",
         "Weather"
     ],
     "apis_used": [
-        "SendMessage",
+        "CurrentWeather",
         "AddReminder",
         "DeleteReminder",
-        "CurrentWeather",
+        "GetReminders",
         "ForecastWeather"
     ],
     "scenario": "The user is a weather enthusiast and wants to compare the current weather of different cities around the world. They want to get the current weather of New York, London, Tokyo, and Sydney (CurrentWeather x 4). They want to save the results in a message to themselves (SendMessage). They want to set a reminder to check the weather again in 24 hours (AddReminder). They want to get the 3-day forecast weather of the same cities (ForecastWeather x 4). They want to delete the reminder they set earlier (DeleteReminder).",
@@ -240,5 +239,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SendMessage",
+        "AddReminder",
+        "DeleteReminder",
+        "CurrentWeather",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Messages",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-ForecastWeather-1.json
+++ b/data/tooltalk/Messages-Reminder-Weather-ForecastWeather-1.json
@@ -239,17 +239,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SendMessage",
-        "AddReminder",
-        "DeleteReminder",
-        "CurrentWeather",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-GetReminder-0.json
+++ b/data/tooltalk/Messages-Reminder-Weather-GetReminder-0.json
@@ -193,17 +193,5 @@
             "role": "user",
             "text": "Thanks"
         }
-    ],
-    "intended_apis_used": [
-        "SearchMessages",
-        "SendMessage",
-        "GetReminders",
-        "CurrentWeather",
-        "ForecastWeather"
-    ],
-    "intended_suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-GetReminder-0.json
+++ b/data/tooltalk/Messages-Reminder-Weather-GetReminder-0.json
@@ -2,15 +2,16 @@
     "name": "Messages-Reminder-Weather-GetReminder-0",
     "conversation_id": "606698d5-ea90-42a3-beed-50f23f629800",
     "suites_used": [
-        "Messages",
+        "Alarm",
         "Reminder",
-        "Weather"
+        "Weather",
+        "Messages"
     ],
     "apis_used": [
-        "SearchMessages",
-        "SendMessage",
-        "GetReminders",
         "CurrentWeather",
+        "GetReminders",
+        "SendMessage",
+        "AddAlarm",
         "ForecastWeather"
     ],
     "scenario": "The user wants to check their reminders for the day (GetReminders). They see that they have a reminder to call their friend Bob, who lives in New York, at 3 pm. They want to know what the weather is like in New York, so they can make some small talk (CurrentWeather). They also want to know if the weather will change in the next few days, so they can suggest some activities for Bob to do (ForecastWeather). They decide to send a message to Bob to confirm the call and mention the weather (SendMessage). They also want to search for any previous messages from Bob that mentioned the weather, to see if he likes it or not (SearchMessages).",
@@ -192,5 +193,17 @@
             "role": "user",
             "text": "Thanks"
         }
+    ],
+    "intended_apis_used": [
+        "SearchMessages",
+        "SendMessage",
+        "GetReminders",
+        "CurrentWeather",
+        "ForecastWeather"
+    ],
+    "intended_suites_used": [
+        "Messages",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-SearchMessage-2.json
+++ b/data/tooltalk/Messages-Reminder-Weather-SearchMessage-2.json
@@ -193,17 +193,5 @@
                 }
             ]
         }
-    ],
-    "intended_apis_used": [
-        "SearchMessages",
-        "SendMessage",
-        "DeleteReminder",
-        "GetReminders",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-SearchMessage-2.json
+++ b/data/tooltalk/Messages-Reminder-Weather-SearchMessage-2.json
@@ -2,15 +2,17 @@
     "name": "Messages-Reminder-Weather-SearchMessage-2",
     "conversation_id": "f5bccae7-ab75-4c20-a5a6-87aa456c36fe",
     "suites_used": [
-        "Messages",
+        "Email",
+        "AccountTools",
         "Reminder",
         "Weather"
     ],
     "apis_used": [
-        "SearchMessages",
-        "SendMessage",
-        "DeleteReminder",
-        "GetReminders",
+        "CurrentWeather",
+        "AddReminder",
+        "SearchInbox",
+        "SendEmail",
+        "GetAccountInformation",
         "HistoricWeather"
     ],
     "scenario": "The user wants to do some research on the weather patterns of New York for a school project. They use HistoricWeather to get the weather data of New York for the past month. They see that the data is incomplete and only has 10 records. They use SearchMessages to look for any messages from their teacher with the query \"weather\". They see that they have a message from two days ago that says they can use any online source for the data. They use SendMessage to thank their teacher and ask for some recommendations. They get a reply with a link to a website that has more data. They use GetReminders to see if they have any reminders for the project. They see that they have one with the task \"Submit weather project\" and the due_date set to next Monday. They use DeleteReminder to delete the reminder and create a new one with the same task and due_date, but with a note that says \"Use website for data\".",
@@ -191,5 +193,17 @@
                 }
             ]
         }
+    ],
+    "intended_apis_used": [
+        "SearchMessages",
+        "SendMessage",
+        "DeleteReminder",
+        "GetReminders",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Messages",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-SendMessage-2.json
+++ b/data/tooltalk/Messages-Reminder-Weather-SendMessage-2.json
@@ -100,17 +100,5 @@
             "role": "user",
             "text": "Thanks"
         }
-    ],
-    "intended_apis_used": [
-        "SendMessage",
-        "AddReminder",
-        "CurrentWeather",
-        "ForecastWeather",
-        "HistoricWeather"
-    ],
-    "intended_suites_used": [
-        "Messages",
-        "Reminder",
-        "Weather"
     ]
 }

--- a/data/tooltalk/Messages-Reminder-Weather-SendMessage-2.json
+++ b/data/tooltalk/Messages-Reminder-Weather-SendMessage-2.json
@@ -2,16 +2,14 @@
     "name": "Messages-Reminder-Weather-SendMessage-2",
     "conversation_id": "d29f91e2-fca5-427c-847c-a33a826e20be",
     "suites_used": [
-        "Messages",
         "Reminder",
-        "Weather"
+        "Weather",
+        "Messages"
     ],
     "apis_used": [
-        "SendMessage",
-        "AddReminder",
         "CurrentWeather",
-        "ForecastWeather",
-        "HistoricWeather"
+        "AddReminder",
+        "SendMessage"
     ],
     "scenario": "The user wants to send a message to their family about their vacation. They first use the HistoricWeather API to get the weather information of the location they visited for the past week. They see that it was mostly rainy and cold. They then use the CurrentWeather API to get the weather information of their current location, which is a different city. They see that it is sunny and warm. They then use the ForecastWeather API to get the weather information of their destination, which is their home city. They see that it is cloudy and mild. They then use the SendMessage API to send their family a message with their weather comparison and some photos of their trip. They also tell their family their flight details and their expected arrival time. They use the AddReminder API to create a reminder to check in with their family when they land.",
     "user": {
@@ -102,5 +100,17 @@
             "role": "user",
             "text": "Thanks"
         }
+    ],
+    "intended_apis_used": [
+        "SendMessage",
+        "AddReminder",
+        "CurrentWeather",
+        "ForecastWeather",
+        "HistoricWeather"
+    ],
+    "intended_suites_used": [
+        "Messages",
+        "Reminder",
+        "Weather"
     ]
 }

--- a/data/tooltalk/golden_conversation_4.json
+++ b/data/tooltalk/golden_conversation_4.json
@@ -303,17 +303,5 @@
             "role": "user",
             "text": "No that seems good. Thanks!"
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm",
-        "FindAlarms",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Calendar",
-        "Email"
     ]
 }

--- a/data/tooltalk/golden_conversation_4.json
+++ b/data/tooltalk/golden_conversation_4.json
@@ -2,16 +2,11 @@
     "name": "golden_conversation_4",
     "conversation_id": "4",
     "suites_used": [
-        "Alarm",
-        "Calendar",
-        "Email"
+        "Calendar"
     ],
     "apis_used": [
-        "AddAlarm",
-        "FindAlarms",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
+        "CreateEvent",
+        "QueryCalendar"
     ],
     "scenario": "The user wants uses (QueryCalendar) to see what events occurred last week. They then copy their meetings for next week using (CreateEvent).",
     "user": {
@@ -308,5 +303,17 @@
             "role": "user",
             "text": "No that seems good. Thanks!"
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm",
+        "FindAlarms",
+        "QueryCalendar",
+        "SearchInbox",
+        "SendEmail"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Calendar",
+        "Email"
     ]
 }

--- a/data/tooltalk/golden_conversation_5.json
+++ b/data/tooltalk/golden_conversation_5.json
@@ -231,17 +231,5 @@
             "role": "user",
             "text": "Fantastic, you're an efficient worker. I'm good for now."
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm",
-        "FindAlarms",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Calendar",
-        "Email"
     ]
 }

--- a/data/tooltalk/golden_conversation_5.json
+++ b/data/tooltalk/golden_conversation_5.json
@@ -4,14 +4,15 @@
     "suites_used": [
         "Alarm",
         "Calendar",
-        "Email"
+        "AccountTools"
     ],
     "apis_used": [
+        "QueryCalendar",
+        "CreateEvent",
         "AddAlarm",
         "FindAlarms",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
+        "RegisterUser",
+        "DeleteAccount"
     ],
     "scenario": "The user wants to create a new account. However, they want to keep any events (no meetings) occurring for the next month. They also want to keep any alarms. The user wants uses (QueryCalendar) to see what events are occurring next month. They then recreate the events for their new account and deletes their old account (DeleteAccount).",
     "user": {
@@ -230,5 +231,17 @@
             "role": "user",
             "text": "Fantastic, you're an efficient worker. I'm good for now."
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm",
+        "FindAlarms",
+        "QueryCalendar",
+        "SearchInbox",
+        "SendEmail"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Calendar",
+        "Email"
     ]
 }

--- a/data/tooltalk/golden_conversation_6.json
+++ b/data/tooltalk/golden_conversation_6.json
@@ -2,16 +2,13 @@
     "name": "golden_conversation_6",
     "conversation_id": "6",
     "suites_used": [
-        "Alarm",
-        "Calendar",
-        "Email"
+        "AccountTools",
+        "Messages"
     ],
     "apis_used": [
-        "AddAlarm",
-        "FindAlarms",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
+        "SendMessage",
+        "RegisterUser",
+        "QueryUser"
     ],
     "scenario": "The user creates a new account then wants to see if their friends have accounts as well. They have their email address, so they use (QueryUser) to look up their username and send them a message (SendMesage).",
     "user": {
@@ -179,5 +176,17 @@
             "role": "user",
             "text": "No that's it"
         }
+    ],
+    "intended_apis_used": [
+        "AddAlarm",
+        "FindAlarms",
+        "QueryCalendar",
+        "SearchInbox",
+        "SendEmail"
+    ],
+    "intended_suites_used": [
+        "Alarm",
+        "Calendar",
+        "Email"
     ]
 }

--- a/data/tooltalk/golden_conversation_6.json
+++ b/data/tooltalk/golden_conversation_6.json
@@ -176,17 +176,5 @@
             "role": "user",
             "text": "No that's it"
         }
-    ],
-    "intended_apis_used": [
-        "AddAlarm",
-        "FindAlarms",
-        "QueryCalendar",
-        "SearchInbox",
-        "SendEmail"
-    ],
-    "intended_suites_used": [
-        "Alarm",
-        "Calendar",
-        "Email"
     ]
 }

--- a/src/scripts/fix_apis_used.py
+++ b/src/scripts/fix_apis_used.py
@@ -1,0 +1,52 @@
+import argparse
+import json
+import os
+from functools import lru_cache
+
+from tooltalk.apis import SUITES_BY_NAME
+
+
+@lru_cache(maxsize=None)
+def api_name_to_suite_name(api_name: str) -> str:
+    for suite_name, suite in SUITES_BY_NAME.items():
+        for api in suite.apis:
+            if api.__name__ == api_name:
+                return suite_name
+    raise ValueError(f"API {api_name} not found")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", dest="dataset_dir", required=True, type=str,
+                        help="Dataset directory")
+    args = parser.parse_args()
+    
+    for fn in os.listdir(args.dataset_dir):
+        path = os.path.join(args.dataset_dir, fn)
+        with open(path, "r", encoding='utf-8') as reader:
+            conversation = json.load(reader)
+
+        apis_used = []
+        for turn in conversation["conversation"]:
+            if "apis" in turn:
+                for api in turn["apis"]:
+                    apis_used.append(api["request"]["api_name"])
+        apis_used = list(set(apis_used))
+        if set(conversation["apis_used"]) != set(apis_used):
+            print(f"Fixing {fn}:", conversation["apis_used"], "=>", apis_used)
+            conversation["intended_apis_used"] = conversation["apis_used"]
+            conversation["apis_used"] = apis_used
+            
+            conversation["intended_suites_used"] = conversation["suites_used"]
+            conversation["suites_used"] = list(set(
+                api_name_to_suite_name(api_name) for api_name in apis_used
+            ))
+
+            with open(path, "w", encoding='utf-8') as writer:
+                json.dump(conversation, writer, indent=4)
+        else:
+            print(f"No need to fix {fn}, skipping ...")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/fix_apis_used.py
+++ b/src/scripts/fix_apis_used.py
@@ -34,10 +34,7 @@ def main():
         apis_used = list(set(apis_used))
         if set(conversation["apis_used"]) != set(apis_used):
             print(f"Fixing {fn}:", conversation["apis_used"], "=>", apis_used)
-            conversation["intended_apis_used"] = conversation["apis_used"]
             conversation["apis_used"] = apis_used
-            
-            conversation["intended_suites_used"] = conversation["suites_used"]
             conversation["suites_used"] = list(set(
                 api_name_to_suite_name(api_name) for api_name in apis_used
             ))


### PR DESCRIPTION
This fixes the `apis_used` and `suites_used` fields in the ground-truth JSONs ~~(their original values are moved into `intended_xxx_used` instead for reference)~~.

These fields are consulted when running the evaluation script using the `--api_mode` option, where `exact` means the model will only choose from those APIs listed in `apis_used`, and `suite` in `suites_used`.
So fixing them will make the `api_mode` option work as expected.